### PR TITLE
Add disabled next and prev buttons

### DIFF
--- a/client/src/Annotator/index.jsx
+++ b/client/src/Annotator/index.jsx
@@ -56,6 +56,7 @@ export const Annotator = ({
   hideHeaderText,
   hideNext,
   hidePrev,
+  disabledNextAndPrev,
   hideClone,
   hideSettings,
   hideSave,
@@ -171,6 +172,7 @@ export const Annotator = ({
           hideHeaderText={hideHeaderText}
           hideNext={hideNext}
           hidePrev={hidePrev}
+          disabledNextAndPrev={disabledNextAndPrev}
           hideClone={hideClone}
           hideSettings={hideSettings}
           hideSave={hideSave}
@@ -216,6 +218,7 @@ Annotator.propTypes = {
   hideHeaderText: PropTypes.bool,
   hideNext: PropTypes.bool,
   hidePrev: PropTypes.bool,
+  disabledNextAndPrev: PropTypes.bool,
   hideClone: PropTypes.bool,
   hideSettings: PropTypes.bool,
   settings: PropTypes.object,

--- a/client/src/DemoSite/index.jsx
+++ b/client/src/DemoSite/index.jsx
@@ -128,8 +128,6 @@ export default () => {
     setLoading(false);
   }, []);
 
-  
-
   return (
     <>
     { !showLabel ? ( // Render loading indicator if loading is true
@@ -159,6 +157,7 @@ export default () => {
         changeSelectedImageIndex(isNaN(updatedIndex ) ? 0 : updatedIndex)
       }}
       hideSettings={true}
+      disabledNextAndPrev={settings.images.length <= 1}
       selectedImageIndex={selectedImageIndex}
     />)}
     </>

--- a/client/src/MainLayout/index.jsx
+++ b/client/src/MainLayout/index.jsx
@@ -43,6 +43,7 @@ export const MainLayout = ({
   hideHeaderText,
   hideNext = false,
   hidePrev = false,
+  disabledNextAndPrev,
   hideClone = false,
   hideSettings = false,
   downloadImage = false,
@@ -221,8 +222,8 @@ export const MainLayout = ({
                 ) : null,
               ].filter(Boolean)}
               headerItems={[
-                !hidePrev && {name: "Prev"},
-                !hideNext && {name: "Next"},
+                !hidePrev && {name: "Prev", disabled: disabledNextAndPrev},
+                !hideNext && {name: "Next", disabled: disabledNextAndPrev},
                 state.annotationType !== "video"
                   ? null
                   : !state.videoPlaying

--- a/client/src/workspace/HeaderButton/index.jsx
+++ b/client/src/workspace/HeaderButton/index.jsx
@@ -30,8 +30,8 @@ const ButtonInnerContent = styled("div")(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
 }))
-const IconContainer = styled("div")(({ textHidden }) => ({
-  color: colors.grey[700],
+const IconContainer = styled("div")(({ textHidden, disabled }) => ({
+  color: disabled ? colors.grey[400] : colors.grey[700],
   height: textHidden ? 32 : 20,
   paddingTop: textHidden ? 8 : 0,
   "& .MuiSvgIcon-root": {
@@ -39,10 +39,10 @@ const IconContainer = styled("div")(({ textHidden }) => ({
     height: 18,
   },
 }))
-const Text = styled("div")(({ theme }) => ({
+const Text = styled("div")(({ theme, disabled }) => ({
   fontWeight: "bold",
   fontSize: 11,
-  color: colors.grey[800],
+  color: disabled ? colors.grey[500] : colors.grey[800],
   display: "flex",
   alignItems: "center",
   lineHeight: 1,
@@ -61,11 +61,11 @@ export const HeaderButton = ({
     <ThemeProvider theme={theme}>
       <StyledButton onClick={onClick} disabled={disabled}>
         <ButtonInnerContent>
-          <IconContainer textHidden={hideText}>
+          <IconContainer textHidden={hideText} disabled={disabled}>
             {icon || getIcon(name, customIconMapping)}
           </IconContainer>
           {!hideText && (
-            <Text>
+            <Text disabled={disabled}>
               <div>{name}</div>
             </Text>
           )}


### PR DESCRIPTION
- Disabled the "prev" and "next" buttons when there is only a single image.
- Changed the color of the buttons when they are disabled.
- Added a new attribute `disabledNextAndPrev` to the `Annotator` component's PropTypes.

![2024-06-05-134125_325x43_scrot](https://github.com/sumn2u/annotate-lab/assets/134330318/a08984f3-4d21-4a18-abb0-73453a62e098)

![2024-06-05-134152_322x37_scrot](https://github.com/sumn2u/annotate-lab/assets/134330318/3b6637e6-082e-4236-9e6d-c32139c7926c)

Fixes #4