### PR TITLE
Changed height of Annotation Page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -24,7 +24,7 @@
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>
-    <div id="app" style="height: 80vh;"></div>
+    <div id="app" style="height: 100vh;"></div> <!-- Changed the height from 80vh to 100vh to make it cover the entire page -->
     <!-- <script>window.global = window;</script> -->
     <script type="module" src="src/index.jsx"></script>
     <!--


### PR DESCRIPTION
The height of the previous annotation page was set to 80vh. Increased the height to cover the full screen.
Issue #6 