### PR TITLE
added fill option value to masked image

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -370,7 +370,7 @@ def download_image_mask():
                     except (ValueError, TypeError) as e:
                         raise ValueError(f"Invalid format in region dimensions: {region}, Error: {e}")
                     # Draw ellipse (circle if rw and rh are equal)
-                    draw.ellipse([rx, ry, rx + rw, ry + rh], outline=color, width=3)
+                    draw.ellipse([rx, ry, rx + rw, ry + rh], outline=color, width=3, fill=color)
 
             mask_byte_arr = BytesIO()
             mask.save(mask_byte_arr, format='PNG')


### PR DESCRIPTION
The missing `fill` option was preventing to fill the region of masked image. It was added in this PR.

Fixed example.
![trashnet_dataset_masked-image (1)](https://github.com/sumn2u/annotate-lab/assets/6531541/8f9a187c-d4b7-4615-9fd1-13fdd0bbd92e)

  Fixes #14 