### PR TITLE
Cache pip packages for future runs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.9
+        cache: 'pip'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Very simple workflow change
Tell the `setup-python` action to cache downloaded pip packages so that it doesn't have to download them every time