### PR TITLE
fixed file type unsupported message not being displayed

### DIFF
--- a/client/src/ImageUpload/index.jsx
+++ b/client/src/ImageUpload/index.jsx
@@ -67,8 +67,9 @@ const ImageUpload = ({ onImageUpload }) => {
       setImages(uploadedImages);
       onImageUpload(uploadedImages);
     } catch (error) {
-      if (error?.data) {
-        showSnackbar(error.data.message, 'error');
+      const errorResponse = error?.response?.data
+      if (errorResponse) {
+        showSnackbar(errorResponse?.message, 'error');
       }else {
         showSnackbar(t("error.server_connection"), 'error')
       }


### PR DESCRIPTION

The logic to read the  error response for file upload is fixed here. 

Preview after fixes: 

![screencapture-localhost-5173-2024-06-13-13_22_48](https://github.com/sumn2u/annotate-lab/assets/6531541/f5449526-4d1c-4dba-93f4-39f912371dbe)

Fixes #8 .

