### PR TITLE
prevent saving information while navigating files

### DIFF
--- a/client/src/Annotator/index.jsx
+++ b/client/src/Annotator/index.jsx
@@ -165,10 +165,8 @@ export const Annotator = ({
           return onExit(without(state, "history"));
         }
       } else if (action.buttonName === "Next" && onNextImage) {
-        saveCurrentData(getActiveImage(state).activeImage);
         return onNextImage(without(state, "history"));
       } else if (action.buttonName === "Prev" && onPrevImage) {
-        saveCurrentData(getActiveImage(state).activeImage);
         return onPrevImage(without(state, "history"));
       } else if (action.buttonName === "Docs" ) {
         return openDocs();

--- a/client/src/FilesListMenu/FilesListMenu.test.js
+++ b/client/src/FilesListMenu/FilesListMenu.test.js
@@ -23,16 +23,23 @@ describe('FilesListMenu', () => {
   const state = {
     "annotationType": "image",
     "showTags": true,
-    "selectedTool": "create-polygon",
+    "selectedTool": "create-box",
     "mode": null,
-    "taskDescription": "dgdg",
+    "taskDescription": "One ",
     "settings": {
-        "taskDescription": "dgdg",
+        "taskDescription": "One ",
         "taskChoice": "image_segmentation",
         "images": [
             {
                 "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
                 "name": "clothes",
+                "selectedClsList": "",
+                "comment": "",
+                "processed": false
+            },
+            {
+                "src": "http://127.0.0.1:5000/uploads/orange.png",
+                "name": "orange",
                 "selectedClsList": "",
                 "comment": "",
                 "processed": false
@@ -42,25 +49,25 @@ describe('FilesListMenu', () => {
         "configuration": {
             "labels": [
                 {
-                    "id": "dfgd"
+                    "id": "One"
                 },
                 {
-                    "id": "dfg"
+                    "id": "Two"
                 }
             ],
             "multipleRegions": true,
             "multipleRegionLabels": true,
             "regionTypesAllowed": [
                 "polygon",
-                "bounding-box",
-                "circle"
+                "circle",
+                "bounding-box"
             ]
         }
     },
     "labelImages": false,
     "regionClsList": [
-        "dfgd",
-        "dfg"
+        "One",
+        "Two"
     ],
     "regionColorList": [],
     "preselectCls": null,
@@ -73,7 +80,635 @@ describe('FilesListMenu', () => {
         "create-polygon",
         "create-circle"
     ],
-    "history": [],
+    "history": [
+        {
+            "time": "2024-06-17T17:41:43.746Z",
+            "state": {
+                "annotationType": "image",
+                "showTags": true,
+                "selectedTool": "create-box",
+                "mode": null,
+                "taskDescription": "One ",
+                "settings": {
+                    "taskDescription": "One ",
+                    "taskChoice": "image_segmentation",
+                    "images": [
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                            "name": "clothes",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        },
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/orange.png",
+                            "name": "orange",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        }
+                    ],
+                    "dataTask": null,
+                    "configuration": {
+                        "labels": [
+                            {
+                                "id": "One"
+                            },
+                            {
+                                "id": "Two"
+                            }
+                        ],
+                        "multipleRegions": true,
+                        "multipleRegionLabels": true,
+                        "regionTypesAllowed": [
+                            "polygon",
+                            "circle",
+                            "bounding-box"
+                        ]
+                    }
+                },
+                "labelImages": false,
+                "regionClsList": [
+                    "One",
+                    "Two"
+                ],
+                "regionColorList": [],
+                "preselectCls": null,
+                "regionTagList": [],
+                "imageClsList": [],
+                "imageTagList": [],
+                "currentVideoTime": 0,
+                "enabledTools": [
+                    "create-box",
+                    "create-polygon",
+                    "create-circle"
+                ],
+                "enabledRegionProps": [
+                    "class",
+                    "comment"
+                ],
+                "selectedImage": 0,
+                "images": [
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        },
+                        "regions": [
+                            {
+                                "type": "box",
+                                "x": 0.27464787836925525,
+                                "y": 0.3584253046565505,
+                                "w": 0.37793427230046944,
+                                "h": 0.39108950136088577,
+                                "highlighted": true,
+                                "editingLabels": false,
+                                "color": "#f44336",
+                                "cls": "One",
+                                "id": "4928182238230594",
+                                "comment": "fox",
+                                "falseInput": false
+                            }
+                        ]
+                    },
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/orange.png",
+                        "name": "orange",
+                        "selectedClsList": "",
+                        "comment": "",
+                        "processed": false
+                    }
+                ],
+                "lastAction": {
+                    "type": "SELECT_IMAGE",
+                    "imageIndex": 0,
+                    "image": {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        },
+                        "regions": [
+                            {
+                                "type": "box",
+                                "x": 0.27464787836925525,
+                                "y": 0.3584253046565505,
+                                "w": 0.37793427230046944,
+                                "h": 0.39108950136088577,
+                                "highlighted": true,
+                                "editingLabels": false,
+                                "color": "#f44336",
+                                "cls": "One",
+                                "id": "4928182238230594",
+                                "comment": "fox",
+                                "falseInput": false
+                            }
+                        ]
+                    }
+                },
+                "selectedCls": "One",
+                "lastMouseMoveCall": 1718646103611,
+                "mouseDownAt": {
+                    "x": 0.8568075027824008,
+                    "y": 0.4588401766275887
+                },
+                "hasNewChange": true
+            },
+            "name": "Create Box"
+        },
+        {
+            "time": "2024-06-17T17:41:41.632Z",
+            "state": {
+                "annotationType": "image",
+                "showTags": true,
+                "selectedTool": "create-box",
+                "mode": null,
+                "taskDescription": "One ",
+                "settings": {
+                    "taskDescription": "One ",
+                    "taskChoice": "image_segmentation",
+                    "images": [
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                            "name": "clothes",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        },
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/orange.png",
+                            "name": "orange",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        }
+                    ],
+                    "dataTask": null,
+                    "configuration": {
+                        "labels": [
+                            {
+                                "id": "One"
+                            },
+                            {
+                                "id": "Two"
+                            }
+                        ],
+                        "multipleRegions": true,
+                        "multipleRegionLabels": true,
+                        "regionTypesAllowed": [
+                            "polygon",
+                            "circle",
+                            "bounding-box"
+                        ]
+                    }
+                },
+                "labelImages": false,
+                "regionClsList": [
+                    "One",
+                    "Two"
+                ],
+                "regionColorList": [],
+                "preselectCls": null,
+                "regionTagList": [],
+                "imageClsList": [],
+                "imageTagList": [],
+                "currentVideoTime": 0,
+                "enabledTools": [
+                    "create-box",
+                    "create-polygon",
+                    "create-circle"
+                ],
+                "enabledRegionProps": [
+                    "class",
+                    "comment"
+                ],
+                "selectedImage": 0,
+                "images": [
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        },
+                        "regions": [
+                            {
+                                "type": "box",
+                                "x": 0.27464787836925525,
+                                "y": 0.3584253046565505,
+                                "w": 0.37793427230046944,
+                                "h": 0.39108950136088577,
+                                "highlighted": true,
+                                "editingLabels": true,
+                                "color": "#f44336",
+                                "cls": "One",
+                                "id": "4928182238230594",
+                                "comment": "fo"
+                            }
+                        ]
+                    },
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/orange.png",
+                        "name": "orange",
+                        "selectedClsList": "",
+                        "comment": "",
+                        "processed": false
+                    }
+                ],
+                "lastAction": {
+                    "type": "CHANGE_REGION",
+                    "region": {
+                        "type": "box",
+                        "x": 0.27464787836925525,
+                        "y": 0.3584253046565505,
+                        "w": 0.37793427230046944,
+                        "h": 0.39108950136088577,
+                        "highlighted": true,
+                        "editingLabels": true,
+                        "color": "#f44336",
+                        "cls": "One",
+                        "id": "4928182238230594",
+                        "comment": "fox"
+                    }
+                },
+                "selectedCls": "One",
+                "lastMouseMoveCall": 1718646099066,
+                "mouseDownAt": null
+            },
+            "name": "Change Region Comment"
+        },
+        {
+            "time": "2024-06-17T17:41:41.424Z",
+            "state": {
+                "annotationType": "image",
+                "showTags": true,
+                "selectedTool": "create-box",
+                "mode": null,
+                "taskDescription": "One ",
+                "settings": {
+                    "taskDescription": "One ",
+                    "taskChoice": "image_segmentation",
+                    "images": [
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                            "name": "clothes",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        },
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/orange.png",
+                            "name": "orange",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        }
+                    ],
+                    "dataTask": null,
+                    "configuration": {
+                        "labels": [
+                            {
+                                "id": "One"
+                            },
+                            {
+                                "id": "Two"
+                            }
+                        ],
+                        "multipleRegions": true,
+                        "multipleRegionLabels": true,
+                        "regionTypesAllowed": [
+                            "polygon",
+                            "circle",
+                            "bounding-box"
+                        ]
+                    }
+                },
+                "labelImages": false,
+                "regionClsList": [
+                    "One",
+                    "Two"
+                ],
+                "regionColorList": [],
+                "preselectCls": null,
+                "regionTagList": [],
+                "imageClsList": [],
+                "imageTagList": [],
+                "currentVideoTime": 0,
+                "enabledTools": [
+                    "create-box",
+                    "create-polygon",
+                    "create-circle"
+                ],
+                "enabledRegionProps": [
+                    "class",
+                    "comment"
+                ],
+                "selectedImage": 0,
+                "images": [
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        },
+                        "regions": [
+                            {
+                                "type": "box",
+                                "x": 0.27464787836925525,
+                                "y": 0.3584253046565505,
+                                "w": 0.37793427230046944,
+                                "h": 0.39108950136088577,
+                                "highlighted": true,
+                                "editingLabels": true,
+                                "color": "#f44336",
+                                "cls": "One",
+                                "id": "4928182238230594",
+                                "comment": "f"
+                            }
+                        ]
+                    },
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/orange.png",
+                        "name": "orange",
+                        "selectedClsList": "",
+                        "comment": "",
+                        "processed": false
+                    }
+                ],
+                "lastAction": {
+                    "type": "CHANGE_REGION",
+                    "region": {
+                        "type": "box",
+                        "x": 0.27464787836925525,
+                        "y": 0.3584253046565505,
+                        "w": 0.37793427230046944,
+                        "h": 0.39108950136088577,
+                        "highlighted": true,
+                        "editingLabels": true,
+                        "color": "#f44336",
+                        "cls": "One",
+                        "id": "4928182238230594",
+                        "comment": "fo"
+                    }
+                },
+                "selectedCls": "One",
+                "lastMouseMoveCall": 1718646099066,
+                "mouseDownAt": null
+            },
+            "name": "Change Region Comment"
+        },
+        {
+            "time": "2024-06-17T17:41:41.283Z",
+            "state": {
+                "annotationType": "image",
+                "showTags": true,
+                "selectedTool": "create-box",
+                "mode": null,
+                "taskDescription": "One ",
+                "settings": {
+                    "taskDescription": "One ",
+                    "taskChoice": "image_segmentation",
+                    "images": [
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                            "name": "clothes",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        },
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/orange.png",
+                            "name": "orange",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        }
+                    ],
+                    "dataTask": null,
+                    "configuration": {
+                        "labels": [
+                            {
+                                "id": "One"
+                            },
+                            {
+                                "id": "Two"
+                            }
+                        ],
+                        "multipleRegions": true,
+                        "multipleRegionLabels": true,
+                        "regionTypesAllowed": [
+                            "polygon",
+                            "circle",
+                            "bounding-box"
+                        ]
+                    }
+                },
+                "labelImages": false,
+                "regionClsList": [
+                    "One",
+                    "Two"
+                ],
+                "regionColorList": [],
+                "preselectCls": null,
+                "regionTagList": [],
+                "imageClsList": [],
+                "imageTagList": [],
+                "currentVideoTime": 0,
+                "enabledTools": [
+                    "create-box",
+                    "create-polygon",
+                    "create-circle"
+                ],
+                "enabledRegionProps": [
+                    "class",
+                    "comment"
+                ],
+                "selectedImage": 0,
+                "images": [
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        },
+                        "regions": [
+                            {
+                                "type": "box",
+                                "x": 0.27464787836925525,
+                                "y": 0.3584253046565505,
+                                "w": 0.37793427230046944,
+                                "h": 0.39108950136088577,
+                                "highlighted": true,
+                                "editingLabels": true,
+                                "color": "#f44336",
+                                "cls": "One",
+                                "id": "4928182238230594"
+                            }
+                        ]
+                    },
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/orange.png",
+                        "name": "orange",
+                        "selectedClsList": "",
+                        "comment": "",
+                        "processed": false
+                    }
+                ],
+                "lastAction": {
+                    "type": "CHANGE_REGION",
+                    "region": {
+                        "type": "box",
+                        "x": 0.27464787836925525,
+                        "y": 0.3584253046565505,
+                        "w": 0.37793427230046944,
+                        "h": 0.39108950136088577,
+                        "highlighted": true,
+                        "editingLabels": true,
+                        "color": "#f44336",
+                        "cls": "One",
+                        "id": "4928182238230594",
+                        "comment": "f"
+                    }
+                },
+                "selectedCls": "One",
+                "lastMouseMoveCall": 1718646099066,
+                "mouseDownAt": null
+            },
+            "name": "Change Region Comment"
+        },
+        {
+            "time": "2024-06-17T17:41:37.192Z",
+            "state": {
+                "annotationType": "image",
+                "showTags": true,
+                "selectedTool": "create-box",
+                "mode": null,
+                "taskDescription": "One ",
+                "settings": {
+                    "taskDescription": "One ",
+                    "taskChoice": "image_segmentation",
+                    "images": [
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                            "name": "clothes",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        },
+                        {
+                            "src": "http://127.0.0.1:5000/uploads/orange.png",
+                            "name": "orange",
+                            "selectedClsList": "",
+                            "comment": "",
+                            "processed": false
+                        }
+                    ],
+                    "dataTask": null,
+                    "configuration": {
+                        "labels": [
+                            {
+                                "id": "One"
+                            },
+                            {
+                                "id": "Two"
+                            }
+                        ],
+                        "multipleRegions": true,
+                        "multipleRegionLabels": true,
+                        "regionTypesAllowed": [
+                            "polygon",
+                            "circle",
+                            "bounding-box"
+                        ]
+                    }
+                },
+                "labelImages": false,
+                "regionClsList": [
+                    "One",
+                    "Two"
+                ],
+                "regionColorList": [],
+                "preselectCls": null,
+                "regionTagList": [],
+                "imageClsList": [],
+                "imageTagList": [],
+                "currentVideoTime": 0,
+                "enabledTools": [
+                    "create-box",
+                    "create-polygon",
+                    "create-circle"
+                ],
+                "enabledRegionProps": [
+                    "class",
+                    "comment"
+                ],
+                "selectedImage": 0,
+                "images": [
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
+                        "name": "clothes",
+                        "selectedClsList": [
+                            "One"
+                        ],
+                        "comment": "",
+                        "processed": false,
+                        "pixelSize": {
+                            "w": 400,
+                            "h": 533
+                        }
+                    },
+                    {
+                        "src": "http://127.0.0.1:5000/uploads/orange.png",
+                        "name": "orange",
+                        "selectedClsList": "",
+                        "comment": "",
+                        "processed": false
+                    }
+                ],
+                "lastAction": {
+                    "type": "SELECT_TOOL",
+                    "selectedTool": "create-box"
+                },
+                "selectedCls": "One",
+                "lastMouseMoveCall": 1718646097081,
+                "mouseDownAt": {
+                    "x": 0.27464787836925525,
+                    "y": 0.3584253046565505
+                }
+            },
+            "name": "Create Box"
+        }
+    ],
     "enabledRegionProps": [
         "class",
         "comment"
@@ -84,8 +719,35 @@ describe('FilesListMenu', () => {
             "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
             "name": "clothes",
             "selectedClsList": [
-                "dfgd"
+                "One"
             ],
+            "comment": "",
+            "processed": false,
+            "pixelSize": {
+                "w": 400,
+                "h": 533
+            },
+            "regions": [
+                {
+                    "type": "box",
+                    "x": 0.27464787836925525,
+                    "y": 0.3584253046565505,
+                    "w": 0.37793427230046944,
+                    "h": 0.39108950136088577,
+                    "highlighted": false,
+                    "editingLabels": false,
+                    "color": "#f44336",
+                    "cls": "One",
+                    "id": "4928182238230594",
+                    "comment": "fox",
+                    "falseInput": false
+                }
+            ]
+        },
+        {
+            "src": "http://127.0.0.1:5000/uploads/orange.png",
+            "name": "orange",
+            "selectedClsList": "",
             "comment": "",
             "processed": false
         }
@@ -97,15 +759,38 @@ describe('FilesListMenu', () => {
             "src": "http://127.0.0.1:5000/uploads/clothes.jpeg",
             "name": "clothes",
             "selectedClsList": [
-                "dfgd"
+                "One"
             ],
             "comment": "",
-            "processed": false
+            "processed": false,
+            "pixelSize": {
+                "w": 400,
+                "h": 533
+            },
+            "regions": [
+                {
+                    "type": "box",
+                    "x": 0.27464787836925525,
+                    "y": 0.3584253046565505,
+                    "w": 0.37793427230046944,
+                    "h": 0.39108950136088577,
+                    "highlighted": false,
+                    "editingLabels": false,
+                    "color": "#f44336",
+                    "cls": "One",
+                    "id": "4928182238230594",
+                    "comment": "fox",
+                    "falseInput": false
+                }
+            ]
         }
     },
-    "selectedCls": "dfgd",
-    "lastMouseMoveCall": 1718142223586
+    "selectedCls": "One",
+    "lastMouseMoveCall": 1718646105660,
+    "mouseDownAt": null,
+    "hasNewChange": true
 }
+
   it('renders correctly', () => {
     const onSelectJumpMock = jest.fn();
     const saveActiveImageMock = jest.fn();
@@ -138,10 +823,15 @@ describe('FilesListMenu', () => {
     fireEvent.click(getByText('Image1'));
 
     // Check if the onClick callback is called with the correct arguments
-    expect(onClickMock).toHaveBeenCalledWith({"activeImage": {"comment": "", "name": "clothes", "processed": false, "selectedClsList": ["dfgd"], "src": "http://127.0.0.1:5000/uploads/clothes.jpeg"}, "currentImageIndex": 0, "pathToActiveImage": ["images", 0]});
+    expect(onClickMock).toHaveBeenCalledWith({"activeImage": {"comment": "", "name": "clothes", "pixelSize": {"h": 533, "w": 400}, "processed": false, "regions": [{"cls": "One", "color": "#f44336", "comment": "fox", "editingLabels": false, "falseInput": false, "h": 0.39108950136088577, "highlighted": false, "id": "4928182238230594", "type": "box", "w": 0.37793427230046944, "x": 0.27464787836925525, "y": 0.3584253046565505}], "selectedClsList": ["One"], "src": "http://127.0.0.1:5000/uploads/clothes.jpeg"}, "currentImageIndex": 0, "pathToActiveImage": ["images", 0]});
 
-    // Check if the onSelectJump and saveActiveImage callbacks are called with the correct arguments
+    // // Check if the onSelectJump and saveActiveImage callbacks are called with the correct arguments
     expect(onSelectJumpMock).toHaveBeenCalledWith('Image1');
-    expect(saveActiveImageMock).toHaveBeenCalledWith({"comment": "", "name": "clothes", "processed": false, "selectedClsList": ["dfgd"], "src": "http://127.0.0.1:5000/uploads/clothes.jpeg"});
+    
+    // simulate click on the first checkbox
+    fireEvent.click(checkboxes[0]);
+
+    //check if the saveActiveImageMock is called with the correct arguments 
+    expect(saveActiveImageMock).toHaveBeenCalledWith({"comment": "", "name": "clothes", "pixelSize": {"h": 533, "w": 400}, "processed": false, "regions": [{"cls": "One", "color": "#f44336", "comment": "fox", "editingLabels": false, "falseInput": false, "h": 0.39108950136088577, "highlighted": false, "id": "4928182238230594", "type": "box", "w": 0.37793427230046944, "x": 0.27464787836925525, "y": 0.3584253046565505}], "selectedClsList": ["One"], "src": "http://127.0.0.1:5000/uploads/clothes.jpeg"})
   });
 });

--- a/client/src/FilesListMenu/index.jsx
+++ b/client/src/FilesListMenu/index.jsx
@@ -64,13 +64,19 @@ export const FilesListMenu = ({
   saveActiveImage,
   onClick
 }) => {
-  const [change, setChange] = useState('')
   const { t } = useTranslation();
+  const [checkedImages, setCheckedImages] = useState({});
+
   const handleClickLabel = (label) => {
     onClick(getActiveImage(state))
-    saveActiveImage(getActiveImage(state).activeImage)
     onSelectJump(label)
-    // setChange(label)
+  }
+
+  const handleCheckBoxClick = (index) => {
+    if (!checkedImages[index]) {
+      setCheckedImages(prevState => ({ ...prevState, [index]: true }))
+    }
+    saveActiveImage(getActiveImage(state).activeImage)
   }
 
   return (
@@ -85,7 +91,6 @@ export const FilesListMenu = ({
         {allImages.map((image, index) => (
           <LabelContainer
             className={classnames({ selected: image.name === selectedImage })}
-            onClick={() => {handleClickLabel(image.name)}}
             key = {index}
           >
 
@@ -97,10 +102,12 @@ export const FilesListMenu = ({
                 color: image.processed ? 'green' : '', // Set color conditionally
               },
             }}
+            checked={!!checkedImages[index]}
+            onClick={() => handleCheckBoxClick(index)}
             data-testid="checkbox"
           />
             <span style={index === selectedImage? {backgroundColor: "rgba(255, 124, 120, 0.5)"} : {}}>
-              <Label className={classnames({ selected: image.name === selectedImage })} style={ { backgroundColor: "withe" }}>
+              <Label className={classnames({ selected: image.name === selectedImage })} style={ { backgroundColor: "withe" }} onClick={() => {handleClickLabel(image.name)}}>
                 {capitalize(image.name)}
               </Label>
             </span>


### PR DESCRIPTION
Saving information while navigating different image files is now prevented. The save action is triggered upon clicking the checkbox in the files list section and through the save button in the header.

Fixes #43 