### PR TITLE
download yolo annotation file in separate text file

### DIFF
--- a/client/src/workspace/DownloadButton/index.jsx
+++ b/client/src/workspace/DownloadButton/index.jsx
@@ -67,7 +67,7 @@ const DownloadButton = ({selectedImageName, classList, hideHeaderText, disabled,
                 if (format === "configuration") {
                     link.setAttribute('download', `configuration`); 
                 } else if (format === "yolo-annotations") {
-                    link.setAttribute('download', `yolo_annotations.txt`);
+                    link.setAttribute('download', `yolo_annotations`);
                 } else if (format === "masked-image") {
                     link.setAttribute('download', "image_masks");
                 } else if (format == "annotated-image"){


### PR DESCRIPTION
Support the creation of an annotation file for each annotated image and the ability to download it as a zip file for YOLO annotation.