### PR TITLE
fix the image preview of bulk images

### DIFF
--- a/client/src/SetupPage/index.jsx
+++ b/client/src/SetupPage/index.jsx
@@ -179,13 +179,13 @@ export const SetupPage = ({setConfiguration, settings, setShowLabel, showAnnotat
             )}
             {currentTab === "images" && (
               <>
-               <Box sx={{ padding: '2rem' }}>
+               <Box sx={{ padding: '2rem' }} maxWidth={"600px"}>
                 <Typography gutterBottom sx={{ fontWeight: 'bold', color: 'rgb(66, 66, 66)', fontSize: '18px' }}>
                   {t("btn.upload_images")}
                 </Typography>
                 <ImageUpload onImageUpload={handleImageUpload} settingsImages={settings.images} />
               </Box>
-              <Box display="flex"  justifyContent="end">
+              <Box display="flex"  justifyContent="end" paddingBottom="6rem">
                 <Button variant="contained" disabled={!isImagesUploaded} onClick={showLab} disableElevation>
                   {t("btn.open_lab")}
                 </Button>


### PR DESCRIPTION
Fixed the preview width of bulk images.

![screencapture-localhost-5173-2024-06-26-17_58_38](https://github.com/sumn2u/annotate-lab/assets/6531541/14d7949a-ca1e-4fe6-8d46-62f133e49e7f)
