### PR TITLE
fix the space issue in urls and image names

### DIFF
--- a/client/src/utils/send-data-to-server.js
+++ b/client/src/utils/send-data-to-server.js
@@ -3,8 +3,8 @@ import config from '../config.js'
 
 export const getImageData = (activeImage) => {
   let imageData = {}
-  imageData['src'] = activeImage.src
-  imageData['name'] = activeImage.name
+  imageData['src'] = decodeURIComponent(activeImage.src)
+  imageData['name'] = decodeURIComponent(activeImage.name)
   imageData['cls'] = activeImage.selectedClsList || []
   imageData['comment'] = activeImage.comment || ""
 

--- a/client/src/workspace/DownloadButton/index.jsx
+++ b/client/src/workspace/DownloadButton/index.jsx
@@ -17,7 +17,7 @@ import config from "../../config.js";
 const DownloadButton = ({selectedImageName, classList, hideHeaderText, disabled, selectedImages}) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const getImageNames = () => { 
-    return selectedImages.map(image => image.src.split('/').pop())
+    return selectedImages.map(image => decodeURIComponent(image.src.split('/').pop()))
   }
   const { showSnackbar } = useSnackbar();
   const {t} = useTranslation();


### PR DESCRIPTION
Use of `decodeURIComponent` to decode the encoded URI components (spaces converted to "%20").