### PR TITLE
preserve settings state in db

### DIFF
--- a/client/src/Annotation/index.jsx
+++ b/client/src/Annotation/index.jsx
@@ -9,7 +9,7 @@ import { getImagesAnnotation } from "../utils/send-data-to-server"
 import CircularProgress from '@mui/material/CircularProgress';
 import Box from '@mui/material/Box';
 import AlertDialog from "../AlertDialog";
-import { clear_db } from "../utils/get-data-from-server"
+import { clear_db, getSettings } from "../utils/get-data-from-server"
 import colors from "../colors.js";
 import {useTranslation} from "react-i18next"
 
@@ -57,7 +57,7 @@ export default () => {
   const [selectedImageIndex, changeSelectedImageIndex] = useState(0)
   const [open, setOpen] = useState(false);
   const {t} = useTranslation();
-  const [showLabel, setShowLabel] = useState(false)
+  const [showLabel, setShowLabel] = useState(true)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [imageNames, setImageNames] = useState([])
   const settingsConfig = useSettings()
@@ -230,20 +230,27 @@ export default () => {
     reloadApp()
   };
 
-  const preloadConfiguration = () => {
-     // get last saved configuration
-     const savedConfiguration = settingsConfig.settings|| {};
-     const lastSavedImageIndex = savedConfiguration.lastSavedImageIndex || 0;
-     if (savedConfiguration.configuration && savedConfiguration.configuration.labels.length > 0) {
-       setSettings(savedConfiguration);
-       if (savedConfiguration.images.length > 0) {
-          fetchImages(savedConfiguration.images, lastSavedImageIndex);
-        }
-     }
-     const showLab = settingsConfig.settings?.showLab || false;
-     if(!isSettingsOpen && showLab) {
-      setShowLabel(showLab)
-     } 
+  const preloadConfiguration = async () => {
+    try {
+      const settings = await getSettings();
+      setShowLabel(false)
+      // get last saved configuration
+      const savedConfiguration = settings|| {};
+      const lastSavedImageIndex = savedConfiguration.lastSavedImageIndex || 0;
+      setSettings(savedConfiguration);
+      if (savedConfiguration.configuration && savedConfiguration.configuration.labels.length > 0) {
+        setSettings(savedConfiguration);
+        if (savedConfiguration.images.length > 0) {
+            await fetchImages(savedConfiguration.images, lastSavedImageIndex);
+          }
+      }
+      const showLab = settingsConfig.settings?.showLab || false;
+      if(!isSettingsOpen && showLab) {
+        setShowLabel(showLab)
+      }
+    } catch (error) {
+      console.error(error);
+    }
   }
   
   const showAnnotationLab = (newSettings) => {
@@ -256,7 +263,6 @@ export default () => {
   useEffect(() => {
     preloadConfiguration();
   }, [ ]);
-
 
   return (
     <>

--- a/client/src/Annotation/index.jsx
+++ b/client/src/Annotation/index.jsx
@@ -234,9 +234,13 @@ export default () => {
     try {
       const settings = await getSettings();
       setShowLabel(false)
+      const localConfiguration = settingsConfig.settings || {};
       // get last saved configuration
-      const savedConfiguration = settings|| {};
-      const lastSavedImageIndex = savedConfiguration.lastSavedImageIndex || 0;
+      const savedConfiguration = settings || {};
+      let lastSavedImageIndex = savedConfiguration.lastSavedImageIndex || 0;
+      if(localConfiguration.lastSavedImageIndex){
+        lastSavedImageIndex = localConfiguration.lastSavedImageIndex;
+      }
       setSettings(savedConfiguration);
       if (savedConfiguration.configuration && savedConfiguration.configuration.labels.length > 0) {
         setSettings(savedConfiguration);

--- a/client/src/Annotation/index.jsx
+++ b/client/src/Annotation/index.jsx
@@ -245,7 +245,7 @@ export default () => {
       if (savedConfiguration.configuration && savedConfiguration.configuration.labels.length > 0) {
         setSettings(savedConfiguration);
         if (savedConfiguration.images.length > 0) {
-            await fetchImages(savedConfiguration.images, lastSavedImageIndex);
+            fetchImages(savedConfiguration.images, lastSavedImageIndex);
           }
       }
       const showLab = settingsConfig.settings?.showLab || false;

--- a/client/src/ConfigurationTask/index.jsx
+++ b/client/src/ConfigurationTask/index.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { useMemo } from "react"
 import Survey from "material-survey/components/Survey"
-import { setIn } from "seamless-immutable"
+import { setIn, asMutable } from "seamless-immutable"
 import { CssBaseline, GlobalStyles } from "@mui/material";
 import {useTranslation} from "react-i18next"
 
@@ -28,12 +28,15 @@ export default ({ config, onChange }) => {
     
       ],
     }
+
     const defaultAnswers = useMemo(
-        () => ({
+        () => asMutable({
           taskDescription: config.taskDescription || "",
           taskChoice: config.taskChoice !== undefined ? config.taskChoice : "image_classification",
-        }),
-        [config.taskDescription, config.taskChoice]
+        },
+         {deep: true}
+         ),
+      [config.taskDescription, config.taskChoice]
       );
     
 

--- a/client/src/SetupPage/index.jsx
+++ b/client/src/SetupPage/index.jsx
@@ -24,6 +24,7 @@ import NoteSection from "../NoteSection";
 import CloseIcon from "@mui/icons-material/Close";
 import useMediaQuery from '@mui/material/useMediaQuery';
 import config from '../config.js';
+import { saveSettings } from "../utils/send-data-to-server.js";
 
 const theme = createTheme()
 
@@ -128,12 +129,13 @@ export const SetupPage = ({setConfiguration, settings, setShowLabel, showAnnotat
     }
   }, [currentTab]);
   
-  const showLab = ()=> {
+  const showLab = async ()=> {
     const hasLabels = configuration.labels.length > 0;
     setShowLabel(hasLabels)
     if(hasLabels) {
       const newSettings = {...settings, showLab: true}
       settingsConfig.changeSetting('settings',newSettings);
+      await saveSettings(newSettings)
       showAnnotationLab(newSettings)
     }
   }

--- a/client/src/SetupPage/index.jsx
+++ b/client/src/SetupPage/index.jsx
@@ -165,7 +165,7 @@ export const SetupPage = ({setConfiguration, settings, setShowLabel, showAnnotat
            sx={{ 
             position: 'absolute', 
             top: isLargeDevice ? '2rem' : '1rem', 
-            right: isLargeDevice ? '10rem' : '1rem', 
+            left: isLargeDevice ? 'calc(100vw - 10rem)' : 'calc(100vw - 3rem)', 
             fontSize: isLargeDevice ? '2rem' : '1.5rem'
           }}>
               {hasShowLab && hasConfig &&  <CloseIcon fontSize={isLargeDevice ? "large" : "medium"} />}

--- a/client/src/utils/get-data-from-server.js
+++ b/client/src/utils/get-data-from-server.js
@@ -36,6 +36,18 @@ export const getLabels = () => {
     })
   }
 
+  export const getSettings = () => {
+    return new Promise((resolve, reject) => {
+      axios.get(`${config.SERVER_URL}/settings`)
+        .then(response => {
+          resolve(response.data);
+        })
+        .catch(error => {
+          reject(error?.response); // Reject with error data
+        });
+    })
+  }
+
 export const clear_db = () => {
   return new Promise((resolve, reject) => {
     axios.post(`${config.SERVER_URL}/clearSession`)

--- a/client/src/utils/send-data-to-server.js
+++ b/client/src/utils/send-data-to-server.js
@@ -38,6 +38,18 @@ export const getImagesAnnotation = (imageData) => {
   });
 };
 
+export const saveSettings = (settings) => {
+  return new Promise((resolve, reject) => {
+    axios.post(`${config.SERVER_URL}/settings`, settings)
+      .then(response => {
+        resolve(response.data); // Resolve with response data
+      })
+      .catch(error => {
+        reject(error.response.data); // Reject with error data
+      });
+  });
+};
+
 export const saveActiveImage = (activeImage) => {
   if (activeImage === null)
     return

--- a/server/app.py
+++ b/server/app.py
@@ -99,10 +99,12 @@ def save_settings(settings):
         json.dump(settings, f, indent=4)
 
 @app.route('/settings', methods=['GET'])
+@cross_origin(origin=client_url, headers=['Content-Type'])
 def get_settings():
     return jsonify(initial_settings)
 
 @app.route('/settings', methods=['POST'])
+@cross_origin(origin=client_url, headers=['Content-Type'])
 def update_settings():
     new_settings = request.json
     initial_settings.update(new_settings)

--- a/server/app.py
+++ b/server/app.py
@@ -35,7 +35,7 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 
 # File path to store task configuration
-JSON_FILE = 'task_config.json'
+JSON_FILE = 'settings.json'
 
 
 # Load initial data from JSON file if exists

--- a/server/settings.json
+++ b/server/settings.json
@@ -1,0 +1,13 @@
+{
+    "taskDescription": "",
+    "taskChoice": "image_classification",
+    "images": [],
+    "showLab": false,
+    "lastSavedImageIndex": null,
+    "configuration": {
+        "labels": [],
+        "multipleRegions": true,
+        "multipleRegionLabels": true,
+        "regionTypesAllowed": []
+    }
+}

--- a/server/settings.json
+++ b/server/settings.json
@@ -1,8 +1,8 @@
 {
-    "taskDescription": "",
+    "taskDescription": "Updated task description",
     "taskChoice": "image_classification",
     "images": [],
-    "showLab": false,
+    "showLab": true,
     "lastSavedImageIndex": null,
     "configuration": {
         "labels": [],

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -29,6 +29,25 @@ class FlaskTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn(b'File type not allowed', response.data)
 
+    def test_get_initial_settings(self):
+        response = self.app.get('/settings')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['taskDescription'], '')
+        self.assertEqual(data['taskChoice'], 'image_classification')
+
+    def test_update_settings(self):
+        updated_settings = {
+            'taskDescription': 'Updated task description',
+            'showLab': True
+        }
+        response = self.app.post('/settings', json=updated_settings)
+        self.assertEqual(response.status_code, 200)
+        response = self.app.get('/settings')
+        data = json.loads(response.data)
+        self.assertEqual(data['taskDescription'], 'Updated task description')
+        self.assertTrue(data['showLab'])
+
     def test_upload_file_success(self):
         data = {
             'file': (BytesIO(b'some file data'), 'test.png')

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 # import os
 import json
 from io import BytesIO
-from app import app
+from app import app, default_settings
 
 class FlaskTestCase(unittest.TestCase):
 
@@ -47,6 +47,27 @@ class FlaskTestCase(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data['taskDescription'], 'Updated task description')
         self.assertTrue(data['showLab'])
+
+    def test_reset_settings(self):
+        # Update settings first to ensure they are not default
+        updated_settings = {
+            'taskDescription': '',
+            'showLab': False
+        }
+        response = self.app.post('/settings', json=updated_settings)
+        self.assertEqual(response.status_code, 200)
+        
+        # Reset settings to default
+        response = self.app.post('/settings/reset')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Settings reset to default values', response.data)
+        
+        # Verify settings are reset to default
+        response = self.app.get('/settings')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        for key, value in default_settings.items():
+            self.assertEqual(data[key], value)
 
     def test_upload_file_success(self):
         data = {


### PR DESCRIPTION
The settings state has been moved to the server, making it independent of the client browser. Below is an attached image showing the same settings in both normal and private windows.

![Screenshot 2024-07-13 at 11 28 30 AM](https://github.com/user-attachments/assets/64440db5-2ff3-4f41-9278-d7abf7e7a469)
![Screenshot 2024-07-13 at 11 27 29 AM](https://github.com/user-attachments/assets/565049b1-c401-47e5-8e49-713123344095)

Fixes #146 