### PR TITLE
create a child process to exit vite application on process kill

### DIFF
--- a/client/client-server.js
+++ b/client/client-server.js
@@ -1,0 +1,17 @@
+import { exec } from 'child_process';
+
+const vite = exec('npx vite');
+
+vite.stdout.on('data', (data) => {
+  console.log(data.toString());
+});
+
+vite.stderr.on('data', (data) => {
+  console.error(data.toString());
+});
+
+process.on('SIGINT', () => {
+  console.log('Killing Vite process');
+  vite.kill('SIGINT');
+  process.exit();
+});

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
   },
   "scripts": {
     "start": "vite --force",
+    "windows-start": "node client-server.js",
     "build": "vite build",
     "test": "jest",
     "format": "prettier --write ."


### PR DESCRIPTION
Added a new script called `windows-start` that listens the child process and kills it on exit.

To run this script run `npm run windows-start` from clients folder.

![24f47464-0f36-43b1-b03f-02c4bc81c080](https://github.com/user-attachments/assets/b8bc2a37-18f4-4be5-ad1b-f49a2ba2836f)
