### PR TITLE
fix  background of download list in dark mode

### DIFF
--- a/client/src/workspace/DownloadButton/index.jsx
+++ b/client/src/workspace/DownloadButton/index.jsx
@@ -13,6 +13,7 @@ import { hexToRgbTuple } from "../../utils/color-utils.js"
 import HeaderButton from "../HeaderButton/index.jsx"
 import { useTranslation } from "react-i18next"
 import config from "../../config.js"
+import { useTheme } from '../../ThemeContext'
 
 const DownloadButton = ({
   selectedImageName,
@@ -97,7 +98,7 @@ const DownloadButton = ({
         showSnackbar(t("error.downloading_file"), "error")
       })
   }
-
+  const { theme } = useTheme();
   return (
     <>
       <HeaderButton
@@ -114,6 +115,8 @@ const DownloadButton = ({
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleClose}
+        sx={{ mt: "1px", "& .MuiMenu-paper":  theme === "dark" ? { backgroundColor: "#333", color: "#fff" } : {}, 
+      }}
       >
         <MenuItem
           onClick={() => handleDownload("configuration")}

--- a/client/src/workspace/HeaderButton/index.jsx
+++ b/client/src/workspace/HeaderButton/index.jsx
@@ -70,7 +70,6 @@ export const HeaderButton = ({
   const customIconMapping = useIconDictionary()
   const isSmallDevice = useMediaQuery(defaultTheme.breakpoints.down("sm"))
   const { theme } = useTheme();
-  console.log(defaultTheme, theme, 'defaultTheme')
   return (
     <ThemeProvider theme={defaultTheme}>
       <StyledButton onClick={onClick} disabled={disabled}>


### PR DESCRIPTION
The background of the download list in dark mode is now showing a black background with white text color.

![Screenshot 2024-07-28 at 12 49 03 AM](https://github.com/user-attachments/assets/527dd9b5-780b-4742-9faf-cd5df1544bd2)

Fixes #176 

