### PR TITLE
persist theme for dark mode

### DIFF
--- a/client/src/Annotation/index.jsx
+++ b/client/src/Annotation/index.jsx
@@ -72,6 +72,7 @@ export default () => {
     taskChoice: "image_classification",
     images: [],
     showLab: false,
+    mode: theme,
     lastSavedImageIndex: null,
     configuration: {
       labels: [],
@@ -267,6 +268,11 @@ export default () => {
       let lastSavedImageIndex = savedConfiguration.lastSavedImageIndex || 0
       if (localConfiguration.lastSavedImageIndex) {
         lastSavedImageIndex = localConfiguration.lastSavedImageIndex
+      }
+      if(localConfiguration.mode){
+        if(theme !== localConfiguration.mode){
+          toggleTheme()
+        }
       }
       setSettings(savedConfiguration)
       if (

--- a/client/src/SetupPage/index.jsx
+++ b/client/src/SetupPage/index.jsx
@@ -95,6 +95,17 @@ export const SetupPage = ({
     setConfiguration({ type: "UPDATE_CONFIGURATION", payload: newConfig })
     showAnnotationLab(newSettings)
   }
+
+  const updateMode = async (mode) => {
+    toggleTheme(mode)
+    const newSettings = {
+      ...settings,
+      mode: mode
+    }
+    settingsConfig.changeSetting("settings", newSettings)
+    await saveSettings(newSettings)
+  }
+  
   const { t } = useTranslation()
 
   const handleImageUpload = (images) => {
@@ -149,7 +160,7 @@ export const SetupPage = ({
     const hasLabels = configuration.labels.length > 0
     setShowLabel(hasLabels)
     if (hasLabels) {
-      const newSettings = { ...settings, showLab: true }
+      const newSettings = { ...settings, mode:theme , showLab: true }
       settingsConfig.changeSetting("settings", newSettings)
       await saveSettings(newSettings)
       showAnnotationLab(newSettings)
@@ -228,7 +239,7 @@ export const SetupPage = ({
                   },
                 })}
                 onClick={() =>
-                  toggleTheme((prev) => (prev === 'light' ? 'dark' : 'light'))
+                  updateMode(theme === 'light' ? 'dark' : 'light')
                 }
                 color="inherit"
                 endIcon={

--- a/server/app.py
+++ b/server/app.py
@@ -42,6 +42,7 @@ default_settings = {
     "taskChoice": "image_classification",
     "images": [],
     "showLab": False,
+    "mode": "light",
     "lastSavedImageIndex": None,
     "configuration": {
         "labels": [],

--- a/server/settings.json
+++ b/server/settings.json
@@ -3,6 +3,7 @@
     "taskChoice": "image_classification",
     "images": [],
     "showLab": true,
+    "mode": "light",
     "lastSavedImageIndex": null,
     "configuration": {
         "labels": [],


### PR DESCRIPTION
The theme values are persisted to have same appearance even after the browser is refreshed.

Fixes #178 