### PR TITLE
disable save btn on absence of images and labels

### DIFF
--- a/client/src/MainLayout/index.jsx
+++ b/client/src/MainLayout/index.jsx
@@ -185,7 +185,8 @@ export const MainLayout = ({
     !nextImage || (nextImage.regions && nextImage.regions.length > 0)
   const selectedImages = state.images.filter((image) => image.selected)
   const hasRegions = state.images[state.selectedImage]?.regions?.length > 0
-  const disableRegion = hasRegions ? false : !state.hasNewChange
+  const disableRegion =  !(state.images.length > 0 && state.regionClsList.length > 0);   // enable save button for all cases
+  // hasRegions ? false : !state.hasNewChange
 
   return (
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
In some cases, images need to be annotated with labels only. To support this, the save button is enabled, allowing us to save the annotated images in the 'uploads' categories folder.