### PR TITLE
fix: show label information on the regions and selectors

### DIFF
--- a/client/src/ImageCanvas/index.jsx
+++ b/client/src/ImageCanvas/index.jsx
@@ -78,6 +78,7 @@ export const ImageCanvas = ({
   modifyingAllowedArea = false,
   keypointDefinitions,
   enabledRegionProps,
+  labels= []
 }) => {
   const canvasEl = useRef(null)
   const layoutParams = useRef({})
@@ -308,6 +309,7 @@ export const ImageCanvas = ({
           <PreventScrollToParents key="regionTags">
             <RegionTags
               regions={regions}
+              labels = {labels}
               projectRegionBox={projectRegionBox}
               mouseEvents={mouseEvents}
               regionClsList={regionClsList}
@@ -451,6 +453,7 @@ ImageCanvas.propTypes = {
   onChangeVideoTime: PropTypes.func.isRequired,
   onRegionClassAdded: PropTypes.func.isRequired,
   onChangeVideoPlaying: PropTypes.func,
+  labels: PropTypes.array
 }
 
 export default ImageCanvas

--- a/client/src/MainLayout/index.jsx
+++ b/client/src/MainLayout/index.jsx
@@ -124,6 +124,7 @@ export const MainLayout = ({
         settings.showCrosshairs &&
         !["select", "pan", "zoom"].includes(state.selectedTool)
       }
+      labels = {settings.settings.configuration.labels || []}
       key={state.selectedImage}
       autoSegmentationOptions={state.autoSegmentationOptions}
       showTags={state.showTags}
@@ -417,6 +418,7 @@ export const MainLayout = ({
               onSelectRegion={action("SELECT_REGION", "region")}
               onDeleteRegion={action("DELETE_REGION", "region")}
               onChangeRegion={action("CHANGE_REGION", "region")}
+              labels = { labels }
             />,
             state.keyframes && (
               <KeyframesSelector

--- a/client/src/RegionLabel/index.jsx
+++ b/client/src/RegionLabel/index.jsx
@@ -29,6 +29,7 @@ export const RegionLabel = ({
   onChange,
   onClose,
   onOpen,
+  labels = [],
   onRegionClassAdded,
   enabledProperties,
 }) => {
@@ -65,7 +66,7 @@ export const RegionLabel = ({
                   className="circle"
                   style={{ backgroundColor: region.color }}
                 />
-                {region.cls}
+                {labels.find((l) => l.id === region.cls)?.description || region.cls}
               </div>
             )}
             {region.tags && (
@@ -149,11 +150,11 @@ export const RegionLabel = ({
                     }}
                     value={
                       region.cls
-                        ? { label: region.cls, value: region.cls }
+                        ? { label: labels.find((l) => l.id === region.cls)?.description || region.cls, value: region.cls }
                         : null
                     }
                     options={asMutable(
-                      allowedClasses.map((c) => ({ value: c, label: c })),
+                      allowedClasses.map((c) => ({ value: c, label: labels.find((l) => l.id === c)?.description || c })),
                     )}
                   />
                 </div>

--- a/client/src/RegionSelectorSidebarBox/index.jsx
+++ b/client/src/RegionSelectorSidebarBox/index.jsx
@@ -276,6 +276,7 @@ export const RegionSelectorSidebarBox = ({
   onDeleteRegion,
   onChangeRegion,
   onSelectRegion,
+  labels = []
 }) => {
   const { t } = useTranslation()
 
@@ -297,6 +298,7 @@ export const RegionSelectorSidebarBox = ({
           <HeaderSep />
           {regions.map((r, i) => (
             <MemoRow
+              name = {labels.find((l) => l.id === r.cls)?.description || name}
               key={r.id}
               {...r}
               region={r}

--- a/client/src/RegionTags/index.jsx
+++ b/client/src/RegionTags/index.jsx
@@ -25,6 +25,7 @@ export const RegionTags = ({
   onDeleteRegion,
   layoutParams,
   imageSrc,
+  labels = [],
   RegionEditLabel,
   onRegionClassAdded,
   enabledRegionProps,
@@ -155,6 +156,7 @@ export const RegionTags = ({
               region={region}
               regions={regions}
               imageSrc={imageSrc}
+              labels= {labels}
               onRegionClassAdded={onRegionClassAdded}
               enabledProperties={enabledRegionProps}
             />


### PR DESCRIPTION
 Labels information are shown on selectors and regions

<img width="1138" height="573" alt="Screenshot 2026-04-13 at 9 15 21 AM" src="https://github.com/user-attachments/assets/42ff6299-9316-4b78-b0b6-7afc95fae9ef" />
