### PR TITLE
update ui for region types selection

### DIFF
--- a/client/src/ConfigureImageSegmentation/index.jsx
+++ b/client/src/ConfigureImageSegmentation/index.jsx
@@ -120,7 +120,13 @@ export default ({ config, onChange }) => {
             ".MuiInputBase-input": {
               width: "350px !important",
             },
-          },
+            ".MuiInputBase-root:has(input[value*='bounding-box']), .MuiInputBase-root:has(input[value*='polygon']), .MuiInputBase-root:has(input[value*='circle'])": {
+              width: "100% !important",
+            },
+            ".MuiInputBase-root:has(input[value*='bounding-box']) .MuiInputBase-input, .MuiInputBase-root:has(input[value*='polygon']) .MuiInputBase-input, .MuiInputBase-root:has(input[value*='circle']) .MuiInputBase-input": {
+              width: "100% !important",
+            }
+          }
         }}
       />
       <SurveyWithConfirmDelete

--- a/client/src/ConfigureObjectDetection/index.jsx
+++ b/client/src/ConfigureObjectDetection/index.jsx
@@ -119,7 +119,13 @@ export default ({ config, onChange }) => {
             ".MuiInputBase-input": {
               width: "350px !important",
             },
-          },
+            ".MuiInputBase-root:has(input[value*='bounding-box']), .MuiInputBase-root:has(input[value*='polygon']), .MuiInputBase-root:has(input[value*='circle'])": {
+              width: "100% !important",
+            },
+            ".MuiInputBase-root:has(input[value*='bounding-box']) .MuiInputBase-input, .MuiInputBase-root:has(input[value*='polygon']) .MuiInputBase-input, .MuiInputBase-root:has(input[value*='circle']) .MuiInputBase-input": {
+              width: "100% !important",
+            }
+          }
         }}
       />
       <SurveyWithConfirmDelete


### PR DESCRIPTION
Now, the region types allowed is clickable and showing dropdown with full width covered.

<img width="830" height="274" alt="Screenshot 2026-06-09 at 10 56 53 AM" src="https://github.com/user-attachments/assets/b3711f10-ecb3-4ecc-ae17-6737d05c3c1d" />
